### PR TITLE
fixes #25 #34 and made performance improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,3 +178,20 @@ multiple runs of [generate.sh](/bin/generate.sh)
 unique.sh <num reducers> <input dir>{ <input dir>}
 ```
 
+As transactions execute they leave a trail of history behind.  The nodes in the
+lower levels of the tree are updated by many transactions and therefore have a
+long history trail.  A long transactional history can slow down transactions.
+Forcing a compaction in Accumulo will clean up this history.  However
+compacting the entire table is expensive.  To avoid this expense, compact only the
+lower levels of the tree.  The following command will compact levels of the
+tree with a maximum number of nodes less than the specified cutoff.
+
+```
+compact-ll.sh <max> <cutoff>
+```
+
+where:
+
+```
+cutoff    = Any level of the tree with a maximum number of nodes that is less than this cutoff will be compacted.
+```

--- a/bin/compact-ll.sh
+++ b/bin/compact-ll.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+BIN_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+. $BIN_DIR/load-env.sh
+
+yarn jar $STRESS_JAR io.fluo.stress.trie.CompactLL $FLUO_PROPS $@
+

--- a/bin/run-test.sh
+++ b/bin/run-test.sh
@@ -68,7 +68,7 @@ fi # TODO setup RegexGroupBalancer built into Accumulo 1.7.0... may be easier to
 hadoop fs -rm -r /stress/
 # add splits to Fluo table
 echo "*****Presplitting table*****"
-$BIN_DIR/split.sh $SPLITS $MAX >$LOG_DIR/split.out 2>$LOG_DIR/split.err
+$BIN_DIR/split.sh $SPLITS >$LOG_DIR/split.out 2>$LOG_DIR/split.err
 
 # generate and load intial data using map reduce writing directly to table
 echo "*****Generating and loading initial data set*****"
@@ -82,6 +82,7 @@ for i in $(seq 1 $ITERATIONS); do
   $BIN_DIR/generate.sh $MAPS $((GEN_INCR / MAPS)) $MAX /stress/$i >$LOG_DIR/generate_$i.out 2>$LOG_DIR/generate_$i.err
   $BIN_DIR/load.sh /stress/$i >$LOG_DIR/load_$i.out 2>$LOG_DIR/load_$i.err
   # TODO could reload the same dataset sometimes, maybe when i%5 == 0 or something
+  $BIN_DIR/compact-ll.sh $MAX $COMPACT_CUTOFF >$LOG_DIR/compact-ll_$i.out 2>$LOG_DIR/compact-ll_$i.err
   sleep $SLEEP
 done
 

--- a/conf/env.sh.example
+++ b/conf/env.sh.example
@@ -37,6 +37,8 @@ GEN_INCR=$((10**3))
 ITERATIONS=3
 #Seconds to sleep between incremental steps.
 SLEEP=30
+#Compact levels with less than the following possible nodes after loads
+COMPACT_CUTOFF=$((256**3 + 1))
 
 ########################
 #config for init-fluo.sh

--- a/pom.xml
+++ b/pom.xml
@@ -174,12 +174,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.accumulo</groupId>
-      <artifactId>accumulo-test</artifactId>
-      <version>${accumulo.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>io.fluo</groupId>
       <artifactId>fluo-integration</artifactId>
       <version>${fluo.version}</version>

--- a/src/main/java/io/fluo/stress/trie/CompactLL.java
+++ b/src/main/java/io/fluo/stress/trie/CompactLL.java
@@ -1,0 +1,61 @@
+package io.fluo.stress.trie;
+
+import java.io.File;
+
+import io.fluo.api.client.FluoClient;
+import io.fluo.api.client.FluoFactory;
+import io.fluo.api.config.FluoConfiguration;
+import io.fluo.core.util.AccumuloUtil;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.hadoop.io.Text;
+
+/**
+ * Compact the lower levels of the tree. The lower levels of the tree contain a small of nodes that
+ * are frequently updated. Compacting these lower levels is a quick operation that cause the Fluo GC
+ * iterator to cleanup past transactions.
+ */
+
+public class CompactLL {
+  public static void main(String[] args) throws Exception {
+
+    if (args.length != 3) {
+      System.err
+          .println("Usage: " + Split.class.getSimpleName() + " <fluo props> <max> <cutoff>");
+      System.exit(-1);
+    }
+
+    FluoConfiguration config = new FluoConfiguration(new File(args[0]));
+
+    long max = Long.parseLong(args[1]);
+
+    //compact levels that can contain less nodes than this
+    int cutoff = Integer.parseInt(args[2]);
+
+    int nodeSize;
+    int stopLevel;
+    try (FluoClient client = FluoFactory.newClient(config)) {
+      nodeSize = client.getAppConfiguration().getInt(Constants.NODE_SIZE_PROP);
+      stopLevel = client.getAppConfiguration().getInt(Constants.STOP_LEVEL_PROP);
+    }
+
+    int level = 64 / nodeSize;
+
+    while(level >= stopLevel) {
+      if(max < cutoff) {
+        break;
+      }
+
+      max = max >> 8;
+      level--;
+    }
+
+    String start = String.format("%02d", stopLevel);
+    String end = String.format("%02d:~", (level));
+
+    System.out.println("Compacting "+start+" to "+end);
+    Connector conn = AccumuloUtil.getConnector(config);
+    conn.tableOperations().compact(config.getAccumuloTable(), new Text(start), new Text(end), true, false);
+
+    System.exit(0);
+  }
+}

--- a/src/main/java/io/fluo/stress/trie/NodeObserver.java
+++ b/src/main/java/io/fluo/stress/trie/NodeObserver.java
@@ -1,69 +1,76 @@
 /*
  * Copyright 2014 Fluo authors (see AUTHORS)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 package io.fluo.stress.trie;
+
+import java.util.Map;
 
 import io.fluo.api.client.TransactionBase;
 import io.fluo.api.data.Bytes;
 import io.fluo.api.data.Column;
 import io.fluo.api.observer.AbstractObserver;
+import io.fluo.api.types.TypedSnapshotBase.Value;
 import io.fluo.api.types.TypedTransactionBase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Observer that looks for count:wait for nodes.  If found,
- * it increments count:seen and increments count:wait of parent
- * node in trie
+/**
+ * Observer that looks for count:wait for nodes. If found, it increments count:seen and increments
+ * count:wait of parent node in trie
  */
 public class NodeObserver extends AbstractObserver {
-  
+
   private static final Logger log = LoggerFactory.getLogger(NodeObserver.class);
 
   private int stopLevel = 0;
-  
+
   @Override
   public void process(TransactionBase tx, Bytes row, Column col) throws Exception {
-    
+
     final TypedTransactionBase ttx = Constants.TYPEL.wrap(tx);
-    final Integer childWait = ttx.get().row(row).col(Constants.COUNT_WAIT_COL).toInteger(0);
-    
+
+    Map<Column, Value> colVals =
+        ttx.get().row(row).columns(Constants.COUNT_SEEN_COL, Constants.COUNT_WAIT_COL);
+
+    final Integer childWait = colVals.get(Constants.COUNT_WAIT_COL).toInteger(0);
+
     if (childWait > 0) {
-      Integer childSeen = ttx.get().row(row).col(Constants.COUNT_SEEN_COL).toInteger(0);
+      Integer childSeen = colVals.get(Constants.COUNT_SEEN_COL).toInteger(0);
 
       ttx.mutate().row(row).col(Constants.COUNT_SEEN_COL).set(childSeen + childWait);
       ttx.mutate().row(row).col(Constants.COUNT_WAIT_COL).delete();
-      
+
       try {
         Node node = new Node(row.toString());
         if (node.getLevel() > stopLevel) {
           Node parent = node.getParent();
-          Integer parentWait = ttx.get().row(parent.getRowId()).col(Constants.COUNT_WAIT_COL).toInteger(0);
-          ttx.mutate().row(parent.getRowId()).col(Constants.COUNT_WAIT_COL).set(parentWait + childWait);
+          Integer parentWait =
+              ttx.get().row(parent.getRowId()).col(Constants.COUNT_WAIT_COL).toInteger(0);
+          ttx.mutate().row(parent.getRowId()).col(Constants.COUNT_WAIT_COL)
+              .set(parentWait + childWait);
         }
       } catch (IllegalArgumentException e) {
         log.error(e.getMessage());
         e.printStackTrace();
-      } 
+      }
     }
   }
-  
+
   @Override
   public void init(Context context) throws Exception {
     stopLevel = context.getAppConfiguration().getInt(Constants.STOP_LEVEL_PROP);
   }
-  
+
   @Override
   public ObservedColumn getObservedColumn() {
     return new ObservedColumn(Constants.COUNT_WAIT_COL, NotificationType.STRONG);

--- a/src/main/java/io/fluo/stress/trie/NumberLoader.java
+++ b/src/main/java/io/fluo/stress/trie/NumberLoader.java
@@ -1,61 +1,67 @@
 /*
  * Copyright 2014 Fluo authors (see AUTHORS)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 package io.fluo.stress.trie;
 
+import java.util.Map;
+
 import io.fluo.api.client.Loader;
 import io.fluo.api.client.TransactionBase;
+import io.fluo.api.data.Column;
+import io.fluo.api.types.TypedSnapshotBase.Value;
 import io.fluo.api.types.TypedTransactionBase;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-/** Executes load transactions of numbers into trie at leaf node level
+/**
+ * Executes load transactions of numbers into trie at leaf node level
  */
 public class NumberLoader implements Loader {
-  
+
   private final Number number;
   private Integer nodeSize = null;
-  
+
   public NumberLoader(Integer num, int nodeSize) {
     checkArgument(num >= 0, "Only positive numbers accepted");
-    checkArgument((nodeSize <= 32) && ((32 % nodeSize) == 0), "nodeSize must be divisor of 32"); 
+    checkArgument((nodeSize <= 32) && ((32 % nodeSize) == 0), "nodeSize must be divisor of 32");
     this.number = num;
     this.nodeSize = nodeSize;
   }
-  
+
   public NumberLoader(Long num) {
     checkArgument(num >= 0, "Only positive numbers accepted");
     this.number = num;
   }
-  
+
   @Override
   public void load(TransactionBase tx, Context context) throws Exception {
-    
-    if(nodeSize == null){
+
+    if (nodeSize == null) {
       nodeSize = context.getAppConfiguration().getInt(Constants.NODE_SIZE_PROP);
       checkArgument((nodeSize <= 64) && ((64 % nodeSize) == 0), "nodeSize must be divisor of 64");
     }
     int level = 64 / nodeSize;
-    
+
     TypedTransactionBase ttx = Constants.TYPEL.wrap(tx);
-    
+
     String rowId = new Node(number, level, nodeSize).getRowId();
-        
-    Integer seen = ttx.get().row(rowId).col(Constants.COUNT_SEEN_COL).toInteger(0);
+
+    Map<Column, Value> colVals =
+        ttx.get().row(rowId).columns(Constants.COUNT_SEEN_COL, Constants.COUNT_WAIT_COL);
+
+    Integer seen = colVals.get(Constants.COUNT_SEEN_COL).toInteger(0);
     if (seen == 0) {
-      Integer wait = ttx.get().row(rowId).col(Constants.COUNT_WAIT_COL).toInteger(0);
+      Integer wait = colVals.get(Constants.COUNT_WAIT_COL).toInteger(0);
       if (wait == 0) {
         ttx.mutate().row(rowId).col(Constants.COUNT_WAIT_COL).set(1);
       }

--- a/src/main/java/io/fluo/stress/trie/Split.java
+++ b/src/main/java/io/fluo/stress/trie/Split.java
@@ -1,17 +1,15 @@
 /*
  * Copyright 2014 Fluo authors (see AUTHORS)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package io.fluo.stress.trie;
@@ -24,44 +22,67 @@ import io.fluo.api.client.FluoClient;
 import io.fluo.api.client.FluoFactory;
 import io.fluo.api.config.FluoConfiguration;
 import io.fluo.core.util.AccumuloUtil;
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.hadoop.io.Text;
 
 public class Split {
 
+  private static final String RGB_CLASS =
+      "org.apache.accumulo.server.master.balancer.RegexGroupBalancer";
+  private static final String RGB_PATTERN_PROP = "table.custom.balancer.group.regex.pattern";
+  private static final String RGB_DEFAULT_PROP = "table.custom.balancer.group.regex.default";
+  private static final String TABLE_BALANCER_PROP = "table.balancer";
+
   public static void main(String[] args) throws Exception {
-    if (args.length != 3) {
-      System.err.println("Usage: " + Split.class.getSimpleName() + " <fluo props> <tablets per level> <max number>");
+    if (args.length != 2) {
+      System.err
+          .println("Usage: " + Split.class.getSimpleName() + " <fluo props> <tablets per level>");
       System.exit(-1);
     }
 
     FluoConfiguration config = new FluoConfiguration(new File(args[0]));
-     
+
     int maxTablets = Integer.parseInt(args[1]);
-    long max = Long.parseLong(args[2]);
 
     int nodeSize;
-    try(FluoClient client = FluoFactory.newClient(config)){
+    int stopLevel;
+    try (FluoClient client = FluoFactory.newClient(config)) {
       nodeSize = client.getAppConfiguration().getInt(Constants.NODE_SIZE_PROP);
+      stopLevel = client.getAppConfiguration().getInt(Constants.STOP_LEVEL_PROP);
     }
+
+    setupBalancer(config);
+
     int level = 64 / nodeSize;
-    int numbersPerTablet = 4096;
-    
-    while(true){
-      int numTablets = (int)Math.min(max / numbersPerTablet, maxTablets);
-      if(numTablets == 0)
+
+    while (level >= stopLevel) {
+      int numTablets = maxTablets;
+      if (numTablets == 0)
         break;
-    
+
       TreeSet<Text> splits = genSplits(level, numTablets);
       addSplits(config, splits);
       System.out.printf("Added %d tablets for level %d\n", numTablets, level);
-      
-      max = max >> nodeSize;
+
       level--;
     }
-    
-    
-    
+  }
+
+  private static void setupBalancer(FluoConfiguration config) throws AccumuloSecurityException {
+    Connector conn = AccumuloUtil.getConnector(config);
+
+    try {
+      // setting this prop first intentionally because it should fail in 1.6
+      conn.tableOperations().setProperty(config.getAccumuloTable(), RGB_PATTERN_PROP, "(\\d\\d).*");
+      conn.tableOperations().setProperty(config.getAccumuloTable(), RGB_DEFAULT_PROP, "none");
+      conn.tableOperations().setProperty(config.getAccumuloTable(), TABLE_BALANCER_PROP, RGB_CLASS);
+      System.out.println("Setup tablet group balancer");
+    } catch (AccumuloException e) {
+      System.err
+          .println("Unable to setup tablet balancer (error expected in 1.6) : " + e.getMessage());
+    }
   }
 
   private static TreeSet<Text> genSplits(int level, int numTablets) {
@@ -69,17 +90,18 @@ public class Split {
     TreeSet<Text> splits = new TreeSet<>();
 
     String ls = String.format("%02d:", level);
-    
+
     int numSplits = numTablets - 1;
-    int distance = (((int)Math.pow(Character.MAX_RADIX, Node.HASH_LEN)-1) / numTablets) + 1;
+    int distance = (((int) Math.pow(Character.MAX_RADIX, Node.HASH_LEN) - 1) / numTablets) + 1;
     int split = distance;
     for (int i = 0; i < numSplits; i++) {
-      splits.add(new Text(ls + Strings.padStart(Integer.toString(split, Character.MAX_RADIX), Node.HASH_LEN, '0')));
+      splits.add(new Text(
+          ls + Strings.padStart(Integer.toString(split, Character.MAX_RADIX), Node.HASH_LEN, '0')));
       split += distance;
     }
 
-    splits.add(new Text(ls));
-    
+    splits.add(new Text(ls+"~"));
+
     return splits;
   }
 


### PR DESCRIPTION
- Modfied observer and loader to do less reads
- Add equal number of splits to all levels of tree.  While running a test I
  noticed the tablet server hosting lowest level was under very high CPU load and
  was a bottleneck.   The lowest level does not have much data, but it does get
  lots of updates and therefore benefits from more tablets.
- Slightly changed the split points.  When using the regex balancer I noticed
  that one tablet in containing the leaf nodes of the tree was not evenly spread.
  Therefore there were two leaf level tablets on a single tablet server.  This
  tablet server became a bottleneck, slowing test.
- Added a command to compact the lower levels of the tree.
